### PR TITLE
Additional check for flyte to prevent user warning

### DIFF
--- a/src/scaffold/conf/__init__.py
+++ b/src/scaffold/conf/__init__.py
@@ -1,10 +1,14 @@
+import importlib.util
+
+
 def register_all() -> None:
     """All @structured_config classes register themselves when imported / defined"""
     from scaffold.conf.scaffold import artifact_manager  # noqa:F401
     from scaffold.conf.scaffold import entrypoint  # noqa:F401
 
     try:
-        from scaffold.conf.scaffold import flyte_launcher  # noqa:F401
+        if importlib.util.find_spec("flytekit") is not None:
+            from scaffold.conf.scaffold import flyte_launcher  # noqa:F401
     except ModuleNotFoundError:
         # in case we didnt install flyte extra package
         pass

--- a/src/scaffold/conf/__init__.py
+++ b/src/scaffold/conf/__init__.py
@@ -6,9 +6,6 @@ def register_all() -> None:
     from scaffold.conf.scaffold import artifact_manager  # noqa:F401
     from scaffold.conf.scaffold import entrypoint  # noqa:F401
 
-    try:
-        if importlib.util.find_spec("flytekit") is not None:
-            from scaffold.conf.scaffold import flyte_launcher  # noqa:F401
-    except ModuleNotFoundError:
-        # in case we didnt install flyte extra package
-        pass
+    if importlib.util.find_spec("flytekit") is not None:
+        # only import in case we installed flyte extra package
+        from scaffold.conf.scaffold import flyte_launcher  # noqa:F401


### PR DESCRIPTION
# Description

Minor follow-up on #12. Added an additional check if flytekit is installed to prevent an unpleasent user warning in scaffold config imports.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [x] Lint and unit tests pass locally with my changes
- [x] I have kept the PR small so that it can be easily reviewed  
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All dependency changes have been reflected in the pip requirement files. 