### PR TITLE
Update Flyte launcher target to be compatible with new plugin structure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mxm-scaffold"
-version = "0.18.2"
+version = "0.18.3"
 description = "Client library Created by the Merantix Momentum AI Platform Team"
 authors = ["Merantix Momentum GmbH"]
 license = "MIT License"

--- a/src/scaffold/conf/scaffold/flyte_launcher.py
+++ b/src/scaffold/conf/scaffold/flyte_launcher.py
@@ -89,7 +89,7 @@ class FlyteNotificationConfig:
 
 @structured_config(group=GROUP, name="flyte")
 class LauncherConfig:
-    _target_: str = "hydra_plugins.flyte_launcher_plugin.flyte_launcher.FlyteLauncher"
+    _target_: str = "hydra_plugins.flyte_launcher_plugin._flyte_launcher.FlyteLauncher"
     execution_environment: ExecutionEnvironmentEnum = ExecutionEnvironmentEnum.remote
     endpoint: str = "localhost:30081"
     build_images: bool = True


### PR DESCRIPTION
# Description

Change in #17 made launcher class not importable using qualified class name with the current default.

Fixes `RuntimeError: Unknown plugin class : 'hydra_plugins.flyte_launcher_plugin.flyte_launcher.FlyteLauncher'`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [x] Lint and unit tests pass locally with my changes
- [x] I have kept the PR small so that it can be easily reviewed  
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 