### PR TITLE
Remove scaffold_store entries

### DIFF
--- a/src/scaffold/conf/__init__.py
+++ b/src/scaffold/conf/__init__.py
@@ -19,10 +19,9 @@ def add_if_not_exists(store: ZenStore, cfg_object: Any, group: str, name: str):
     cs = ConfigStore.instance()
     try:
         cs.list(group)
-        print(cs.list(group))
         if f"{name}.yaml" not in cs.list(group):
             store(cfg_object, group=group, name=name)
-    except KeyError:
+    except (KeyError, IOError):
         # group doesn't exist yet, safe to add
         store(cfg_object, group=group, name=name)
 

--- a/src/scaffold/conf/scaffold/artifact_manager.py
+++ b/src/scaffold/conf/scaffold/artifact_manager.py
@@ -1,7 +1,6 @@
 from hydra_zen import builds
 from omegaconf import MISSING
 
-from scaffold.conf import scaffold_store
 from scaffold.data.artifact_manager.filesystem import FileSystemArtifactManager
 from scaffold.data.artifact_manager.wandb import WandbArtifactManager
 
@@ -20,6 +19,3 @@ FileSystemArtifactManagerConf = builds(
     url=MISSING,
     fs_kwargs={},
 )
-
-scaffold_store(WandbArtifactManagerConf, group=GROUP, name="WandbArtifactManagerConf")
-scaffold_store(FileSystemArtifactManagerConf, group=GROUP, name="FileSystemArtifactManagerConf")

--- a/src/scaffold/conf/scaffold/ctx_manager.py
+++ b/src/scaffold/conf/scaffold/ctx_manager.py
@@ -1,7 +1,6 @@
 from hydra_zen import builds
 from omegaconf import MISSING
 
-from scaffold.conf import scaffold_store
 from scaffold.ctx_manager import WandBContext
 
 WandBContextConf = builds(
@@ -18,5 +17,3 @@ WandBContextConf = builds(
     user=None,
     resume=False,
 )
-
-scaffold_store(WandBContextConf, group="ctx_manager", name="WandBContextConf")

--- a/src/scaffold/conf/scaffold/entrypoint/__init__.py
+++ b/src/scaffold/conf/scaffold/entrypoint/__init__.py
@@ -1,6 +1,5 @@
 from hydra_zen import make_config
 
-from scaffold.conf import scaffold_store
 from scaffold.ctx_manager import (  # noqa: F401
     DEFAULT_LOGGING,
     DISABLED_LOGGING,
@@ -19,4 +18,3 @@ EntrypointConf = make_config(
     logging=DEFAULT_LOGGING,  # Same options as hydra.job_logging; override per logging variant
     verbose=False,  # Same as hydra.verbose, but applied to our logging setup
 )
-scaffold_store(EntrypointConf, group=GROUP, name="EntrypointConf")

--- a/src/scaffold/conf/scaffold/flyte_launcher.py
+++ b/src/scaffold/conf/scaffold/flyte_launcher.py
@@ -2,13 +2,10 @@ from hydra_zen import builds
 from omegaconf import MISSING
 
 from hydra_plugins.flyte_launcher_plugin._flyte_launcher import FlyteLauncher
-from scaffold.conf import scaffold_store
-from scaffold.flyte.launcher_conf import (
-    ExecutionEnvironmentEnum,
-    FlyteDockerImageConf,
-    FlyteNotificationConf,
-    FlyteWorkflowConf,
-)
+from scaffold.flyte.launcher_conf import FlyteDockerImageConf  # noqa: F401
+from scaffold.flyte.launcher_conf import FlyteNotificationConf  # noqa: F401
+from scaffold.flyte.launcher_conf import FlyteWorkflowConf  # noqa: F401
+from scaffold.flyte.launcher_conf import ExecutionEnvironmentEnum
 
 FlyteLauncherConf = builds(
     FlyteLauncher,
@@ -20,7 +17,3 @@ FlyteLauncherConf = builds(
     workflow=MISSING,
     notifications=[],
 )
-
-scaffold_store(FlyteDockerImageConf, group="scaffold/flyte_launcher", name="FlyteDockerImageConf")
-scaffold_store(FlyteWorkflowConf, group="scaffold/flyte_launcher", name="FlyteWorkflowConf")
-scaffold_store(FlyteNotificationConf, group="scaffold/flyte_launcher", name="FlyteNotificationConf")

--- a/src/scaffold/conf/scaffold/lightning/callbacks.py
+++ b/src/scaffold/conf/scaffold/lightning/callbacks.py
@@ -1,7 +1,6 @@
 from hydra_zen import builds
 from omegaconf import MISSING
 
-from scaffold.conf import scaffold_store
 from scaffold.torch.lightning.callbacks import LightningCheckpointer
 
 GROUP = "scaffold/lightning/checkpointer"
@@ -15,5 +14,3 @@ LightningCheckpointerConf = builds(
     resume_checkpoint_version=None,
     only_log_current_best=False,
 )
-
-scaffold_store(LightningCheckpointerConf, group=GROUP, name="LightningCheckpointerConf")

--- a/src/scaffold/hydra/config_helpers.py
+++ b/src/scaffold/hydra/config_helpers.py
@@ -133,10 +133,8 @@ def structured_config(
         Use :func:`hydra_zen.builds` and :func:`hydra_zen.store` instead::
 
             from hydra_zen import builds
-            from scaffold.conf import scaffold_store
 
             MyConf = builds(MyClass, arg=value)
-            scaffold_store(MyConf, group="my/group", name="MyConf")
 
         This decorator will be removed in a future release.
 

--- a/test/scaffold/plugins/test_hydra_plugins.py
+++ b/test/scaffold/plugins/test_hydra_plugins.py
@@ -20,20 +20,11 @@ def test_discovery() -> None:
     assert flyte_launcher.FlyteLauncher.__name__ in [x.__name__ for x in Plugins.instance().discover(Launcher)]
 
 
-def test_config_installed() -> None:
-    """Tests if the scaffold configs are correctly added to the config store."""
-    with initialize(config_path=None):
-        config_loader = GlobalHydra.instance().config_loader()
-        assert "WandbArtifactManagerConf" in config_loader.get_group_options("scaffold/artifact_manager")
-        assert "FlyteWorkflowConf" in config_loader.get_group_options("scaffold/flyte_launcher")
-
-
 def test_flyte_config_installed() -> None:
     """Tests if the flyte related configs are correctly added to the config store."""
     with initialize(config_path=None):
         config_loader = GlobalHydra.instance().config_loader()
-        assert "FlyteDockerImageConf" in config_loader.get_group_options("scaffold/flyte_launcher")
-        assert "FlyteWorkflowConf" in config_loader.get_group_options("scaffold/flyte_launcher")
+        assert "FlyteWorkflowConfig" in config_loader.get_group_options("scaffold/flyte_launcher")
 
 
 def test_hydra_plugin_available() -> None:
@@ -47,8 +38,7 @@ def test_hydra_plugin_available() -> None:
 @pytest.mark.parametrize(
     "config_name",
     [
-        "scaffold/flyte_launcher/FlyteDockerImageConf",
-        "scaffold/flyte_launcher/FlyteWorkflowConf",
+        "scaffold/flyte_launcher/FlyteWorkflowConfig",
     ],
 )
 def test_config_store_available_through_plugin(config_name: str) -> None:


### PR DESCRIPTION
# Description

Remove configs added to the `scaffold_store` in favor of using the configs types created with `builds`. The added values from before still had missing values and were not really usable. Instead, such added configs should be fully specified and be ready to be used out of the box.