### PR TITLE
Add hydra legacy compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mxm-scaffold"
-version = "0.20.0"
+version = "0.20.1"
 description = "Merantix Momentum AI Platform client library"
 authors = [
     {name = "Merantix Momentum GmbH"}

--- a/src/scaffold/conf/__init__.py
+++ b/src/scaffold/conf/__init__.py
@@ -1,8 +1,30 @@
 import importlib.util
+from typing import Any
 
+from hydra.core.config_store import ConfigStore
 from hydra_zen import ZenStore
 
 scaffold_store = ZenStore(name="scaffold")
+legacy_scaffold_store = ZenStore(name="scaffold_legacy")
+
+
+def add_if_not_exists(store: ZenStore, cfg_object: Any, group: str, name: str):
+    """Add a config to the store if it doesn't already exist.
+    Args:
+        store: the ZenStore to add to
+        cfg_object: the config object to add
+        group: the Hydra config group to add to
+        name: the name of the config within the group
+    """
+    cs = ConfigStore.instance()
+    try:
+        cs.list(group)
+        print(cs.list(group))
+        if f"{name}.yaml" not in cs.list(group):
+            store(cfg_object, group=group, name=name)
+    except KeyError:
+        # group doesn't exist yet, safe to add
+        store(cfg_object, group=group, name=name)
 
 
 def register_all() -> None:
@@ -20,3 +42,12 @@ def register_all() -> None:
         from scaffold.conf.scaffold.lightning import callbacks  # noqa: F401
 
     scaffold_store.add_to_hydra_store(overwrite_ok=True)
+
+    from scaffold.conf.scaffold.flyte_launcher import FlyteLauncherConf
+    from scaffold.flyte.launcher_conf import FlyteWorkflowConf
+
+    # to maintain backwards compatibility, add legacy configs to the store if they were not set by the user already
+    add_if_not_exists(legacy_scaffold_store, FlyteLauncherConf, "hydra/launcher", "flyte")
+    add_if_not_exists(legacy_scaffold_store, FlyteWorkflowConf, "scaffold/flyte_launcher", "FlyteWorkflowConfig")
+
+    legacy_scaffold_store.add_to_hydra_store(overwrite_ok=True)

--- a/src/scaffold/flyte/core.py
+++ b/src/scaffold/flyte/core.py
@@ -256,6 +256,9 @@ def build_workflow_inputs(
 
     # backwards compatible: legacy flyte workflows expect a single top level "cfg" or "config", non-exploded
     if len(wf_inputs.keys()) == 1 and ("cfg" in wf_inputs or "config" in wf_inputs):
+        logger.warning(
+            "Building workflow inputs in legacy mode. Assuming that the workflow handles config-splitting on its own."
+        )
         inputs[list(wf_inputs.keys())[0]] = job_cfg
 
     else:

--- a/src/scaffold/flyte/core.py
+++ b/src/scaffold/flyte/core.py
@@ -238,7 +238,7 @@ def build_workflow_inputs(
       built from Hydra's logging configuration.
     - Otherwise: looks up the value as ``job_cfg.<name>``.  Emits a warning
       when no matching key exists (the workflow default is used in that case).
-
+    - For legacy compatibility, if the workflow only expects "cfg" or "config", do not explode the config
     Args:
         workflow (WorkflowBase): A flytekit ``@workflow``-decorated function.
         job_cfg (DictConfig): Hydra user config (i.e. ``cfg`` with the ``hydra`` key removed).
@@ -249,10 +249,17 @@ def build_workflow_inputs(
         dict[str, Any]: Mapping of workflow parameter names to their resolved values.
     """
     inputs: dict[str, Any] = {}
-    for name in workflow.interface.inputs:
-        if name == runtime_cfg_key:
-            inputs[name] = build_runtime_cfg(hydra_cfg)
-        else:
+    wf_inputs = workflow.interface.inputs
+
+    if runtime_cfg_key in wf_inputs:
+        inputs[runtime_cfg_key] = build_runtime_cfg(hydra_cfg)
+
+    # backwards compatible: legacy flyte workflows expect a single top level "cfg" or "config", non-exploded
+    if len(wf_inputs.keys()) == 1 and ("cfg" in wf_inputs or "config" in wf_inputs):
+        inputs[list(wf_inputs.keys())[0]] = job_cfg
+
+    else:
+        for name in wf_inputs:
             val = OmegaConf.select(job_cfg, name)
             if val is None:
                 logger.warning(

--- a/uv.lock
+++ b/uv.lock
@@ -2194,7 +2194,7 @@ wheels = [
 
 [[package]]
 name = "mxm-scaffold"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "." }
 dependencies = [
     { name = "hydra-zen" },


### PR DESCRIPTION
# Description
This PR implements backward compatibility fixes, making scaffold 0.20 non-breaking, i.e. projects using 0.19 will be able just upgrade without changing code.

pair-coded with @yolibernal 

Fixes https://github.com/merantix-momentum/bi-ba-ml/issues/533

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [x] Lint and unit tests pass locally with my changes
- [x] I have kept the PR small so that it can be easily reviewed  
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All dependency changes have been reflected in the pip requirement files. 