### PR TITLE
add secret plugin for multiple providers aws, gcp, azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Install the extras you need for your project. For example, to install the Flyte 
 * *torch:* Utilities for working with PyTorch
 * *monitoring:* Utilities for monitoring training jobs
 * *wandb:* Utilities for logging to Weights and Biases
+* *aws_secrets:* AWS Secret Manager integration for Hydra
+* *gcp_secrets:* GCP Secret Manager integration for Hydra
+* *azure_secrets:* Azure Key Vault integration for Hydra
 * *dev:* Dependencies required for development and running tests
 
 ## 📖 Documentation

--- a/docs/usage/subpackages.rst
+++ b/docs/usage/subpackages.rst
@@ -8,6 +8,7 @@ Scaffold has several loosely coupled subpackages, which are motivated and their 
    :caption: Contents:
 
    subpackages/hydra
+   subpackages/secrets_plugins
    subpackages/iterstream
    subpackages/catalog
    subpackages/artifact_manager

--- a/docs/usage/subpackages/secrets_plugins.rst
+++ b/docs/usage/subpackages/secrets_plugins.rst
@@ -1,0 +1,145 @@
+.. _secrets-plugins:
+
+Secrets Plugins
+================
+
+Scaffold provides Hydra plugins for seamless integration with cloud secret managers. These plugins register custom OmegaConf resolvers that fetch secrets on-demand during configuration resolution, allowing secure injection of secrets into your configs without hardcoding values.
+
+**Supported Providers:**
+
+* AWS Secrets Manager (``aws_secrets`` extra)
+* Google Cloud Secret Manager (``gcp_secrets`` extra)
+* Azure Key Vault (``azure_secrets`` extra)
+
+Features
+--------
+
+* **Lazy Evaluation:** Secrets are fetched only when accessed, not at config load time
+* **Automatic Registration:** Plugins auto-register on Hydra initialization via plugin discovery
+* **JSON Support:** Extract specific keys from JSON-formatted secrets
+* **No Hardcoded Values:** Config files show only resolver strings, never actual secrets
+* **Type Safe:** Proper error messages for misconfiguration
+
+Installation
+------------
+
+Install the cloud provider extra you need:
+
+.. code-block:: bash
+
+    # AWS
+    pip install mxm-scaffold[aws_secrets]
+
+    # Google Cloud
+    pip install mxm-scaffold[gcp_secrets]
+
+    # Azure
+    pip install mxm-scaffold[azure_secrets]
+
+Or install all secrets plugins:
+
+.. code-block:: bash
+
+    pip install mxm-scaffold[all]
+
+Google Cloud Secret Manager (GCP)
+----------------------------------
+
+The GCP plugin provides a ``gcp_secret`` resolver for accessing secrets from GCP Secret Manager.
+
+Configuration in YAML
+""""""""""""""""""""""
+
+.. code-block:: yaml
+
+    database:
+      # Simple string secret
+      password: "${gcp_secret:my-project-id/db-password}"
+
+      # Extract a key from a JSON secret
+      username: "${gcp_secret:my-project-id/db-credentials,username}"
+      api_key: "${gcp_secret:my-project-id/db-credentials,api_key}"
+
+    auth:
+      # Using full resource name
+      token: "${gcp_secret:projects/my-project-123/secrets/auth-token/versions/latest}"
+
+Authentication
+"""""""""""""""
+
+GCP Secret Manager uses Application Default Credentials. Ensure your environment is configured:
+
+.. code-block:: bash
+
+    export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json
+
+Testing with Real GCP Resources
+"""""""""""""""""""""""""""""""""
+
+To test the GCP plugin with actual secrets:
+
+1. **Install dependencies:**
+
+   .. code-block:: bash
+
+       uv sync --extra gcp_secrets
+
+2. **Update the test configuration** at ``test/hydra_plugins/manual/gcp_secret_real_case.yaml``:
+
+   Replace ``my-project-id`` and secret names with your actual GCP project ID and secret names:
+
+   .. code-block:: yaml
+
+       secrets:
+         service_token: "${gcp_secret:YOUR-GCP-PROJECT-ID/your-secret-name}"
+         db_username: "${gcp_secret:YOUR-GCP-PROJECT-ID/db-credentials,username}"
+         db_password: "${gcp_secret:YOUR-GCP-PROJECT-ID/db-credentials,password}"
+
+3. **Set up GCP credentials:**
+
+   .. code-block:: bash
+
+       export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json
+
+4. **Run the integration test:**
+
+   .. code-block:: bash
+
+       python test/hydra_plugins/manual/run_gcp_secret_real_case.py
+
+   This will resolve all ``gcp_secret`` interpolations against real GCP Secret Manager. By default, secret values are redacted for safety. To see full values (on secure terminals only):
+
+   .. code-block:: bash
+
+       python test/hydra_plugins/manual/run_gcp_secret_real_case.py --show-values
+
+AWS Secrets Manager
+--------------------
+
+The AWS plugin provides an ``aws_secret`` resolver for accessing secrets from AWS Secrets Manager.
+
+Configuration in YAML
+""""""""""""""""""""""
+
+.. code-block:: yaml
+
+    database:
+      password: "${aws_secret:my-database-secret}"
+      username: "${aws_secret:my-database-secret,username}"
+
+See ``src/hydra_plugins/aws_secrets_plugin/README.md`` for detailed documentation.
+
+Azure Key Vault
+----------------
+
+The Azure plugin provides an ``azure_secret`` resolver for accessing secrets from Azure Key Vault.
+
+Configuration in YAML
+""""""""""""""""""""""
+
+.. code-block:: yaml
+
+    database:
+      password: "${azure_secret:my-vault,my-secret}"
+
+See ``src/hydra_plugins/azure_secrets_plugin/README.md`` for detailed documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,11 @@ Repository = "https://github.com/merantix-momentum/scaffold-core/"
 Documentation = "https://docs.scaffold.merantix-momentum.cloud/"
 Homepage = "https://merantix-momentum.com"
 
+[project.entry-points."hydra_plugins"]
+aws_secrets = "hydra_plugins.aws_secrets_plugin.aws_secrets_plugin:register_aws_resolver"
+gcp_secrets = "hydra_plugins.gcp_secrets_plugin.gcp_secrets_plugin:register_gcp_resolver"
+azure_secrets = "hydra_plugins.azure_secrets_plugin.azure_secrets_plugin:register_azure_resolver"
+
 [project.optional-dependencies]
 # data
 data = [
@@ -72,6 +77,20 @@ aim = [
     "aim>=3.29.1",
     "fsspec>=2024.12.0",
     "gcsfs>=2024.12.0",
+]
+
+# secrets managers
+aws_secrets = [
+    "boto3",
+]
+
+gcp_secrets = [
+    "google-cloud-secret-manager",
+]
+
+azure_secrets = [
+    "azure-identity",
+    "azure-keyvault-secrets",
 ]
 
 [dependency-groups]

--- a/src/hydra_plugins/aws_secrets_plugin/README.md
+++ b/src/hydra_plugins/aws_secrets_plugin/README.md
@@ -1,0 +1,55 @@
+# AWS Secrets Manager Plugin
+
+This plugin registers an OmegaConf custom resolver for AWS Secrets Manager, enabling secure lazy-loaded secret injection into Hydra configurations.
+
+## Installation
+
+### Option 1: Install with optional dependency (recommended)
+
+```bash
+pip install mxm-scaffold[aws_secrets]
+```
+
+### Option 2: Install SDK directly
+
+```bash
+pip install boto3
+```
+
+## Usage in YAML Configs
+
+```yaml
+database:
+  password: "${aws_secret:secret_name, key_name}"
+  host: "prod-db.example.com"
+```
+
+### Arguments
+
+- `secret_id`: The name or ARN of the secret in AWS Secrets Manager
+- `key` (optional): If the secret is JSON-formatted, extract this specific key from it
+
+## Examples
+
+### Simple String Secret
+
+```yaml
+api:
+  token: "${aws_secret:prod/api/token}"
+```
+
+### JSON Secret with Key Extraction
+
+```yaml
+database:
+  password: "${aws_secret:prod/db/credentials, password}"
+  username: "${aws_secret:prod/db/credentials, username}"
+```
+
+## Features
+
+- **Lazy Evaluation**: Secrets are fetched only when accessed, not at config load time
+- **No Hardcoded Values**: Config files show only the resolver string, never the actual secret
+- **Automatic Registration**: The plugin auto-registers on Hydra initialization
+- **JSON Support**: Extract specific keys from JSON-formatted secrets
+- **Type Safe**: Proper error messages for misconfiguration

--- a/src/hydra_plugins/aws_secrets_plugin/__init__.py
+++ b/src/hydra_plugins/aws_secrets_plugin/__init__.py
@@ -1,0 +1,5 @@
+"""AWS Secrets Manager resolver for Hydra.
+
+Registers a custom OmegaConf resolver for AWS Secrets Manager to enable secure,
+lazy-loaded secret injection into Hydra configurations.
+"""

--- a/src/hydra_plugins/aws_secrets_plugin/aws_secrets_plugin.py
+++ b/src/hydra_plugins/aws_secrets_plugin/aws_secrets_plugin.py
@@ -1,0 +1,65 @@
+"""AWS Secrets Manager resolver plugin.
+
+This module automatically registers an OmegaConf resolver for AWS Secrets Manager
+when Hydra initializes. Secrets are fetched lazily on-demand.
+
+Usage in YAML configs:
+    password: "${aws_secret:secret_name, key_name}"
+"""
+import json
+from typing import Optional
+
+from omegaconf import OmegaConf
+
+
+def get_aws_secret(secret_id: str, key: Optional[str] = None) -> str:
+    """Fetch a secret from AWS Secrets Manager.
+
+    Args:
+        secret_id: The name or ARN of the secret in Secrets Manager.
+        key: Optional key if the secret is JSON. If provided, returns the value
+             for that key from the JSON secret string.
+
+    Returns:
+        The secret value as a string.
+
+    Raises:
+        ImportError: If boto3 is not installed.
+        Exception: If the secret cannot be retrieved from AWS.
+    """
+    try:
+        import boto3
+    except ImportError:
+        raise ImportError(
+            "boto3 is not installed. Install it with: pip install boto3"
+        )
+
+    client = boto3.client("secretsmanager")
+    response = client.get_secret_value(SecretId=secret_id)
+
+    secret_str = response.get("SecretString") or response.get("SecretBinary", "")
+
+    if key:
+        try:
+            secret_dict = json.loads(secret_str)
+            return secret_dict.get(key, "")
+        except json.JSONDecodeError:
+            raise ValueError(
+                f"Secret '{secret_id}' is not valid JSON. "
+                f"Cannot extract key '{key}'."
+            )
+
+    return secret_str
+
+
+def register_aws_resolver() -> None:
+    """Register the AWS Secrets Manager resolver with OmegaConf.
+
+    This function is called automatically when Hydra initializes due to the
+    plugin discovery mechanism.
+    """
+    OmegaConf.register_new_resolver("aws_secret", get_aws_secret, replace=True)
+
+
+# Automatically register resolver when this module is imported
+register_aws_resolver()

--- a/src/hydra_plugins/aws_secrets_plugin/aws_secrets_plugin.py
+++ b/src/hydra_plugins/aws_secrets_plugin/aws_secrets_plugin.py
@@ -30,9 +30,7 @@ def get_aws_secret(secret_id: str, key: Optional[str] = None) -> str:
     try:
         import boto3
     except ImportError:
-        raise ImportError(
-            "boto3 is not installed. Install it with: pip install boto3"
-        )
+        raise ImportError("boto3 is not installed. Install it with: pip install boto3")
 
     client = boto3.client("secretsmanager")
     response = client.get_secret_value(SecretId=secret_id)
@@ -44,10 +42,7 @@ def get_aws_secret(secret_id: str, key: Optional[str] = None) -> str:
             secret_dict = json.loads(secret_str)
             return secret_dict.get(key, "")
         except json.JSONDecodeError:
-            raise ValueError(
-                f"Secret '{secret_id}' is not valid JSON. "
-                f"Cannot extract key '{key}'."
-            )
+            raise ValueError(f"Secret '{secret_id}' is not valid JSON. " f"Cannot extract key '{key}'.")
 
     return secret_str
 

--- a/src/hydra_plugins/azure_secrets_plugin/README.md
+++ b/src/hydra_plugins/azure_secrets_plugin/README.md
@@ -1,0 +1,77 @@
+# Azure Key Vault Plugin
+
+This plugin registers an OmegaConf custom resolver for Azure Key Vault, enabling secure lazy-loaded secret injection into Hydra configurations.
+
+## Installation
+
+### Option 1: Install with optional dependency (recommended)
+
+```bash
+pip install mxm-scaffold[azure_secrets]
+```
+
+### Option 2: Install SDKs directly
+
+```bash
+pip install azure-identity azure-keyvault-secrets
+```
+
+## Usage in YAML Configs
+
+```yaml
+auth:
+  token: "${azure_secret:my-vault, my-secret}"
+```
+
+### Arguments
+
+- `vault_name`: The name of the Key Vault (just the vault name, not the full URL)
+- `secret_name`: The name of the secret to retrieve
+
+## Examples
+
+### Simple Secret
+
+```yaml
+api:
+  key: "${azure_secret:my-vault, api-key}"
+```
+
+### Multiple Secrets
+
+```yaml
+database:
+  host: "prod-db.example.com"
+  username: "${azure_secret:my-vault, db-username}"
+  password: "${azure_secret:my-vault, db-password}"
+```
+
+## Features
+
+- **Lazy Evaluation**: Secrets are fetched only when accessed, not at config load time
+- **No Hardcoded Values**: Config files show only the resolver string, never the actual secret
+- **Automatic Registration**: The plugin auto-registers on Hydra initialization
+- **Type Safe**: Proper error messages for misconfiguration
+
+## Authentication
+
+Azure Key Vault uses `DefaultAzureCredential` for authentication, which checks credentials in the following order:
+
+1. Environment variables (`AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`)
+2. Managed Identity (if running on Azure services)
+3. Azure CLI credentials
+4. Interactive browser login
+
+Example with service principal:
+
+```bash
+export AZURE_CLIENT_ID="your-client-id"
+export AZURE_CLIENT_SECRET="your-client-secret"
+export AZURE_TENANT_ID="your-tenant-id"
+```
+
+## Vault Access Requirements
+
+Ensure the authenticated principal has the following Key Vault permissions:
+- `secrets/get` - Read secrets from the vault
+- `secrets/list` - List secrets in the vault

--- a/src/hydra_plugins/azure_secrets_plugin/__init__.py
+++ b/src/hydra_plugins/azure_secrets_plugin/__init__.py
@@ -1,0 +1,5 @@
+"""Azure Key Vault resolver for Hydra.
+
+Registers a custom OmegaConf resolver for Azure Key Vault to enable secure,
+lazy-loaded secret injection into Hydra configurations.
+"""

--- a/src/hydra_plugins/azure_secrets_plugin/azure_secrets_plugin.py
+++ b/src/hydra_plugins/azure_secrets_plugin/azure_secrets_plugin.py
@@ -1,0 +1,55 @@
+"""Azure Key Vault resolver plugin.
+
+This module automatically registers an OmegaConf resolver for Azure Key Vault
+when Hydra initializes. Secrets are fetched lazily on-demand.
+
+Usage in YAML configs:
+    token: "${azure_secret:vault_name, secret_name}"
+"""
+
+from omegaconf import OmegaConf
+
+
+def get_azure_secret(vault_name: str, secret_name: str) -> str:
+    """Fetch a secret from Azure Key Vault.
+
+    Args:
+        vault_name: The name of the Key Vault (just the vault name, not full URL).
+        secret_name: The name of the secret to retrieve.
+
+    Returns:
+        The secret value as a string.
+
+    Raises:
+        ImportError: If azure-identity or azure-keyvault-secrets is not installed.
+        Exception: If the secret cannot be retrieved from Azure.
+    """
+    try:
+        from azure.identity import DefaultAzureCredential
+        from azure.keyvault.secrets import SecretClient
+    except ImportError:
+        raise ImportError(
+            "azure-identity and azure-keyvault-secrets are not installed. "
+            "Install them with: "
+            "pip install azure-identity azure-keyvault-secrets"
+        )
+
+    vault_url = f"https://{vault_name}.vault.azure.net"
+    credential = DefaultAzureCredential()
+    client = SecretClient(vault_url=vault_url, credential=credential)
+
+    secret = client.get_secret(secret_name)
+    return secret.value
+
+
+def register_azure_resolver() -> None:
+    """Register the Azure Key Vault resolver with OmegaConf.
+
+    This function is called automatically when Hydra initializes due to the
+    plugin discovery mechanism.
+    """
+    OmegaConf.register_new_resolver("azure_secret", get_azure_secret, replace=True)
+
+
+# Automatically register resolver when this module is imported
+register_azure_resolver()

--- a/src/hydra_plugins/flyte_launcher_plugin/_flyte_launcher.py
+++ b/src/hydra_plugins/flyte_launcher_plugin/_flyte_launcher.py
@@ -20,6 +20,7 @@ from hydra.types import HydraContext, TaskFunction
 from omegaconf import DictConfig, OmegaConf, open_dict
 
 from scaffold.constants import RUNTIME_CFG_KEY
+from scaffold.config_masking import mask_sensitive_config
 from scaffold.flyte.launcher_conf import (
     ExecutionEnvironmentEnum,
     FlyteDockerImageConf,
@@ -445,7 +446,7 @@ class FlyteLauncher(Launcher):
         with open_dict(job_cfg):
             del job_cfg["hydra"]
 
-        inputs = build_workflow_inputs(workflow, job_cfg, cfg.hydra, runtime_cfg_key)
+        inputs = mask_sensitive_config(build_workflow_inputs(workflow, job_cfg, cfg.hydra, runtime_cfg_key))
 
         kwargs = {}
         if (cron_exp := cfg.hydra.launcher.workflow.cron_schedule) is not None:

--- a/src/hydra_plugins/flyte_launcher_plugin/_flyte_launcher.py
+++ b/src/hydra_plugins/flyte_launcher_plugin/_flyte_launcher.py
@@ -19,8 +19,8 @@ from hydra.plugins.launcher import Launcher
 from hydra.types import HydraContext, TaskFunction
 from omegaconf import DictConfig, OmegaConf, open_dict
 
-from scaffold.constants import RUNTIME_CFG_KEY
 from scaffold.config_masking import mask_sensitive_config
+from scaffold.constants import RUNTIME_CFG_KEY
 from scaffold.flyte.launcher_conf import (
     ExecutionEnvironmentEnum,
     FlyteDockerImageConf,

--- a/src/hydra_plugins/gcp_secrets_plugin/README.md
+++ b/src/hydra_plugins/gcp_secrets_plugin/README.md
@@ -1,0 +1,69 @@
+# GCP Secret Manager Plugin
+
+This plugin registers an OmegaConf custom resolver for GCP Secret Manager, enabling secure lazy-loaded secret injection into Hydra configurations.
+
+## Installation
+
+### Option 1: Install with optional dependency (recommended)
+
+```bash
+pip install mxm-scaffold[gcp_secrets]
+```
+
+### Option 2: Install SDK directly
+
+```bash
+pip install google-cloud-secret-manager
+```
+
+## Usage in YAML Configs
+
+```yaml
+database:
+  api_key: "${gcp_secret:my-project/secret-name, api_key}"
+```
+
+### Arguments
+
+- `secret_name`: The GCP secret (format: `project_id/secret_name` or full resource name `projects/project_id/secrets/secret_name/versions/latest`)
+- `key` (optional): If the secret is JSON-formatted, extract this specific key from it
+
+## Examples
+
+### Simple String Secret
+
+```yaml
+auth:
+  token: "${gcp_secret:my-project/auth-token}"
+```
+
+### JSON Secret with Key Extraction
+
+```yaml
+database:
+  password: "${gcp_secret:my-project/db-credentials, password}"
+  username: "${gcp_secret:my-project/db-credentials, username}"
+```
+
+### Full Resource Name
+
+```yaml
+api:
+  key: "${gcp_secret:projects/my-project-123/secrets/api-key/versions/latest}"
+```
+
+## Features
+
+- **Lazy Evaluation**: Secrets are fetched only when accessed, not at config load time
+- **No Hardcoded Values**: Config files show only the resolver string, never the actual secret
+- **Automatic Registration**: The plugin auto-registers on Hydra initialization
+- **JSON Support**: Extract specific keys from JSON-formatted secrets
+- **Type Safe**: Proper error messages for misconfiguration
+
+## Authentication
+
+GCP Secret Manager uses Application Default Credentials. Ensure your environment has proper credentials configured:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json
+```

--- a/src/hydra_plugins/gcp_secrets_plugin/__init__.py
+++ b/src/hydra_plugins/gcp_secrets_plugin/__init__.py
@@ -1,0 +1,5 @@
+"""GCP Secret Manager resolver for Hydra.
+
+Registers a custom OmegaConf resolver for GCP Secret Manager to enable secure,
+lazy-loaded secret injection into Hydra configurations.
+"""

--- a/src/hydra_plugins/gcp_secrets_plugin/gcp_secrets_plugin.py
+++ b/src/hydra_plugins/gcp_secrets_plugin/gcp_secrets_plugin.py
@@ -1,0 +1,85 @@
+"""GCP Secret Manager resolver plugin.
+
+This module automatically registers an OmegaConf resolver for GCP Secret Manager
+when Hydra initializes. Secrets are fetched lazily on-demand.
+
+Usage in YAML configs:
+    api_key: "${gcp_secret:project_id/secret_name, key_name}"
+"""
+import json
+from typing import Optional
+
+from omegaconf import OmegaConf
+
+
+def get_gcp_secret(secret_name: str, key: Optional[str] = None) -> str:
+    """Fetch a secret from GCP Secret Manager.
+
+    Args:
+        secret_name: The name of the secret (format: "project_id/secret_name" or
+                     "projects/project_id/secrets/secret_name/versions/latest").
+        key: Optional key if the secret is JSON. If provided, returns the value
+             for that key from the JSON secret string.
+
+    Returns:
+        The secret value as a string.
+
+    Raises:
+        ImportError: If google-cloud-secret-manager is not installed.
+        ValueError: If the secret format is invalid or secret is not valid JSON.
+        Exception: If the secret cannot be retrieved from GCP.
+    """
+    try:
+        from google.cloud import secretmanager
+    except ImportError:
+        raise ImportError(
+            "google-cloud-secret-manager is not installed. "
+            "Install it with: pip install google-cloud-secret-manager"
+        )
+
+    # Handle both short format (project/secret) and full format
+    if secret_name.startswith("projects/"):
+        resource_name = secret_name
+    else:
+        # Extract project and secret from simplified format
+        parts = secret_name.split("/")
+        if len(parts) == 2:
+            project_id, secret_id = parts
+            resource_name = (
+                f"projects/{project_id}/secrets/{secret_id}/versions/latest"
+            )
+        else:
+            raise ValueError(
+                f"Invalid GCP secret format: {secret_name}. "
+                f"Use 'project_id/secret_name' or full resource name."
+            )
+
+    client = secretmanager.SecretManagerServiceClient()
+    response = client.access_secret_version(request={"name": resource_name})
+
+    secret_str = response.payload.data.decode("UTF-8")
+
+    if key:
+        try:
+            secret_dict = json.loads(secret_str)
+            return secret_dict.get(key, "")
+        except json.JSONDecodeError:
+            raise ValueError(
+                f"Secret '{secret_name}' is not valid JSON. "
+                f"Cannot extract key '{key}'."
+            )
+
+    return secret_str
+
+
+def register_gcp_resolver() -> None:
+    """Register the GCP Secret Manager resolver with OmegaConf.
+
+    This function is called automatically when Hydra initializes due to the
+    plugin discovery mechanism.
+    """
+    OmegaConf.register_new_resolver("gcp_secret", get_gcp_secret, replace=True)
+
+
+# Automatically register resolver when this module is imported
+register_gcp_resolver()

--- a/src/hydra_plugins/gcp_secrets_plugin/gcp_secrets_plugin.py
+++ b/src/hydra_plugins/gcp_secrets_plugin/gcp_secrets_plugin.py
@@ -33,8 +33,7 @@ def get_gcp_secret(secret_name: str, key: Optional[str] = None) -> str:
         from google.cloud import secretmanager
     except ImportError:
         raise ImportError(
-            "google-cloud-secret-manager is not installed. "
-            "Install it with: pip install google-cloud-secret-manager"
+            "google-cloud-secret-manager is not installed. " "Install it with: pip install google-cloud-secret-manager"
         )
 
     # Handle both short format (project/secret) and full format
@@ -45,13 +44,10 @@ def get_gcp_secret(secret_name: str, key: Optional[str] = None) -> str:
         parts = secret_name.split("/")
         if len(parts) == 2:
             project_id, secret_id = parts
-            resource_name = (
-                f"projects/{project_id}/secrets/{secret_id}/versions/latest"
-            )
+            resource_name = f"projects/{project_id}/secrets/{secret_id}/versions/latest"
         else:
             raise ValueError(
-                f"Invalid GCP secret format: {secret_name}. "
-                f"Use 'project_id/secret_name' or full resource name."
+                f"Invalid GCP secret format: {secret_name}. " f"Use 'project_id/secret_name' or full resource name."
             )
 
     client = secretmanager.SecretManagerServiceClient()
@@ -64,10 +60,7 @@ def get_gcp_secret(secret_name: str, key: Optional[str] = None) -> str:
             secret_dict = json.loads(secret_str)
             return secret_dict.get(key, "")
         except json.JSONDecodeError:
-            raise ValueError(
-                f"Secret '{secret_name}' is not valid JSON. "
-                f"Cannot extract key '{key}'."
-            )
+            raise ValueError(f"Secret '{secret_name}' is not valid JSON. " f"Cannot extract key '{key}'.")
 
     return secret_str
 

--- a/src/scaffold/config_masking.py
+++ b/src/scaffold/config_masking.py
@@ -1,0 +1,45 @@
+import re
+import typing as t
+
+from omegaconf import DictConfig, ListConfig, OmegaConf
+
+MASKED_VALUE = "***MASKED***"
+
+_SENSITIVE_KEY_PATTERN = re.compile(
+    r"(secret|token|password|passwd|credential|api[_-]?key|private[_-]?key|access[_-]?key)",
+    flags=re.IGNORECASE,
+)
+_SECRET_RESOLVER_PATTERN = re.compile(r"\$\{\s*(aws_secret|azure_secret|gcp_secret)\s*:", flags=re.IGNORECASE)
+
+
+def _is_sensitive_key(key: str) -> bool:
+    return bool(_SENSITIVE_KEY_PATTERN.search(key))
+
+
+def _looks_like_secret_resolver(value: t.Any) -> bool:
+    return isinstance(value, str) and bool(_SECRET_RESOLVER_PATTERN.search(value))
+
+
+def _mask_node(node: t.Any, parent_key: t.Optional[str] = None) -> t.Any:
+    if isinstance(node, dict):
+        return {k: _mask_node(v, parent_key=k) for k, v in node.items()}
+
+    if isinstance(node, list):
+        return [_mask_node(v, parent_key=parent_key) for v in node]
+
+    if (parent_key is not None and _is_sensitive_key(parent_key)) or _looks_like_secret_resolver(node):
+        return MASKED_VALUE
+
+    return node
+
+
+def mask_sensitive_config(cfg: t.Any) -> t.Any:
+    """Return a copy of cfg with sensitive values masked for safe logging/registration.
+
+    DictConfig/ListConfig are converted with resolve=False to avoid resolving resolvers
+    while preparing telemetry or metadata payloads.
+    """
+    if isinstance(cfg, (DictConfig, ListConfig)):
+        cfg = OmegaConf.to_container(cfg, resolve=False)
+
+    return _mask_node(cfg)

--- a/src/scaffold/ctx_manager.py
+++ b/src/scaffold/ctx_manager.py
@@ -5,6 +5,8 @@ from contextlib import AbstractContextManager, contextmanager, ExitStack
 
 from omegaconf import DictConfig, OmegaConf
 
+from scaffold.config_masking import mask_sensitive_config
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_LOGGING: dict = {
@@ -204,7 +206,7 @@ class WandBContext(AbstractContextManager):
         else:
             import flatten_dict
 
-            config = flatten_dict.flatten(dict(self.run_config), reducer="dot")
+            config = flatten_dict.flatten(mask_sensitive_config(self.run_config), reducer="dot")
             self.run = wandb.init(
                 entity=self.entity,
                 id=self.run_id,

--- a/test/hydra_plugins/__init__.py
+++ b/test/hydra_plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Conftest for hydra_plugins tests."""

--- a/test/hydra_plugins/test_resolvers.py
+++ b/test/hydra_plugins/test_resolvers.py
@@ -1,0 +1,34 @@
+"""Tests for secrets resolver plugins.
+
+These are integration tests that verify the resolvers work with OmegaConf.
+They don't test the actual cloud API calls since those SDKs aren't installed.
+"""
+from omegaconf import OmegaConf
+
+from hydra_plugins.aws_secrets_plugin.aws_secrets_plugin import register_aws_resolver
+from hydra_plugins.gcp_secrets_plugin.gcp_secrets_plugin import register_gcp_resolver
+from hydra_plugins.azure_secrets_plugin.azure_secrets_plugin import (
+    register_azure_resolver,
+)
+
+
+class TestResolverRegistration:
+    """Test that all resolvers can be registered with OmegaConf."""
+
+    def test_aws_resolver_registration(self) -> None:
+        """Test AWS resolver registration."""
+        register_aws_resolver()
+        cfg = OmegaConf.create({"secret": "${aws_secret:test}"})
+        assert cfg is not None
+
+    def test_gcp_resolver_registration(self) -> None:
+        """Test GCP resolver registration."""
+        register_gcp_resolver()
+        cfg = OmegaConf.create({"secret": "${gcp_secret:test}"})
+        assert cfg is not None
+
+    def test_azure_resolver_registration(self) -> None:
+        """Test Azure resolver registration."""
+        register_azure_resolver()
+        cfg = OmegaConf.create({"secret": "${azure_secret:vault, secret}"})
+        assert cfg is not None

--- a/test/hydra_plugins/test_resolvers.py
+++ b/test/hydra_plugins/test_resolvers.py
@@ -6,10 +6,8 @@ They don't test the actual cloud API calls since those SDKs aren't installed.
 from omegaconf import OmegaConf
 
 from hydra_plugins.aws_secrets_plugin.aws_secrets_plugin import register_aws_resolver
+from hydra_plugins.azure_secrets_plugin.azure_secrets_plugin import register_azure_resolver
 from hydra_plugins.gcp_secrets_plugin.gcp_secrets_plugin import register_gcp_resolver
-from hydra_plugins.azure_secrets_plugin.azure_secrets_plugin import (
-    register_azure_resolver,
-)
 
 
 class TestResolverRegistration:

--- a/test/scaffold/flyte/test_launchplan_masking.py
+++ b/test/scaffold/flyte/test_launchplan_masking.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+import pytest
+from omegaconf import OmegaConf
+
+from scaffold.config_masking import MASKED_VALUE
+
+pytest.importorskip("flytekit")
+from hydra_plugins.flyte_launcher_plugin._flyte_launcher import FlyteLauncher
+
+
+class _DummyWorkflow:
+    interface = SimpleNamespace(inputs={"db_password": object(), "username": object()})
+
+
+def test_create_launchplan_masks_sensitive_default_inputs(monkeypatch) -> None:
+    """LaunchPlan defaults should not persist secret values from config."""
+    captured = {}
+
+    class _DummyLaunchPlan:
+        def __init__(self) -> None:
+            self.name = "dummy_lp"
+
+    def _mock_create(*args, **kwargs):
+        captured["default_inputs"] = kwargs["default_inputs"]
+        return _DummyLaunchPlan()
+
+    import flytekit
+
+    monkeypatch.setattr(flytekit.LaunchPlan, "create", _mock_create)
+
+    cfg = OmegaConf.create(
+        {
+            "hydra": {
+                "launcher": {"workflow": {"cron_schedule": None}},
+                "hydra_logging": {"version": 1},
+                "verbose": False,
+            },
+            "db_password": "top-secret",
+            "username": "alice",
+        }
+    )
+
+    FlyteLauncher._create_launchplan(
+        workflow=_DummyWorkflow(),
+        cfg=cfg,
+        module_name="dummy.module",
+        idx=0,
+        config_name="test",
+        notifications=[],
+    )
+
+    assert captured["default_inputs"]["db_password"] == MASKED_VALUE
+    assert captured["default_inputs"]["username"] == "alice"

--- a/test/scaffold/flyte/test_launchplan_masking.py
+++ b/test/scaffold/flyte/test_launchplan_masking.py
@@ -3,10 +3,10 @@ from types import SimpleNamespace
 import pytest
 from omegaconf import OmegaConf
 
+from hydra_plugins.flyte_launcher_plugin._flyte_launcher import FlyteLauncher
 from scaffold.config_masking import MASKED_VALUE
 
 pytest.importorskip("flytekit")
-from hydra_plugins.flyte_launcher_plugin._flyte_launcher import FlyteLauncher
 
 
 class _DummyWorkflow:

--- a/test/scaffold/test_config_masking.py
+++ b/test/scaffold/test_config_masking.py
@@ -1,0 +1,22 @@
+from omegaconf import OmegaConf
+
+from scaffold.config_masking import MASKED_VALUE, mask_sensitive_config
+
+
+def test_mask_sensitive_config_masks_sensitive_keys_and_resolvers() -> None:
+    cfg = OmegaConf.create(
+        {
+            "api_key": "abc123",
+            "db": {"password": "pw", "host": "localhost"},
+            "resolver_value": "${aws_secret:my_secret}",
+            "safe": "ok",
+        }
+    )
+
+    masked = mask_sensitive_config(cfg)
+
+    assert masked["api_key"] == MASKED_VALUE
+    assert masked["db"]["password"] == MASKED_VALUE
+    assert masked["resolver_value"] == MASKED_VALUE
+    assert masked["db"]["host"] == "localhost"
+    assert masked["safe"] == "ok"

--- a/test/scaffold/test_config_masking.py
+++ b/test/scaffold/test_config_masking.py
@@ -1,6 +1,6 @@
 from omegaconf import OmegaConf
 
-from scaffold.config_masking import MASKED_VALUE, mask_sensitive_config
+from scaffold.config_masking import mask_sensitive_config, MASKED_VALUE
 
 
 def test_mask_sensitive_config_masks_sensitive_keys_and_resolvers() -> None:

--- a/test/scaffold/test_ctx_manager.py
+++ b/test/scaffold/test_ctx_manager.py
@@ -2,7 +2,9 @@ import typing as t
 from test.conftest import MockContextManager
 
 import pytest
+from omegaconf import OmegaConf
 
+from scaffold.config_masking import MASKED_VALUE
 from scaffold.ctx_manager import combined_context, TimerContext, WandBContext
 
 WandB = WandBContext(base_url="wand.com", project="mock_project")
@@ -28,6 +30,32 @@ def test_wandbctx_exit_with_exception(mock_wandb: t.Any) -> None:
             raise Exception("This is a test exception")
 
     assert mock_wandb.finish.call_args.kwargs["exit_code"] == 1
+
+
+def test_wandbctx_masks_sensitive_run_config(mock_wandb: t.Any) -> None:
+    """Test that sensitive values are masked before config is passed to wandb.init."""
+    ctx = WandBContext(
+        base_url="wand.com",
+        project="mock_project",
+        run_config=OmegaConf.create(
+            {
+                "service": {"password": "super-secret", "host": "localhost"},
+                "api_key": "abc123",
+                "resolver_value": "${aws_secret:my_secret}",
+                "normal_value": "safe",
+            }
+        ),
+    )
+
+    with ctx as _:
+        pass
+
+    init_config = mock_wandb.init.call_args.kwargs["config"]
+    assert init_config["service.password"] == MASKED_VALUE
+    assert init_config["api_key"] == MASKED_VALUE
+    assert init_config["resolver_value"] == MASKED_VALUE
+    assert init_config["service.host"] == "localhost"
+    assert init_config["normal_value"] == "safe"
 
 
 def test_timer_ctx_manager(mock_logger) -> None:

--- a/test/scaffold/test_ctx_manager.py
+++ b/test/scaffold/test_ctx_manager.py
@@ -34,6 +34,7 @@ def test_wandbctx_exit_with_exception(mock_wandb: t.Any) -> None:
 
 def test_wandbctx_masks_sensitive_run_config(mock_wandb: t.Any) -> None:
     """Test that sensitive values are masked before config is passed to wandb.init."""
+    mock_wandb.run = None  # Simulate that there's no existing run
     ctx = WandBContext(
         base_url="wand.com",
         project="mock_project",

--- a/uv.lock
+++ b/uv.lock
@@ -367,6 +367,20 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-keyvault-secrets"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/b8/03c7b4edd1e3355ad5fffb70e68af70cd09542963f45cf3a2aa9fb3930b5/azure_keyvault_secrets-4.11.0.tar.gz", hash = "sha256:ac14727b9159cca353173ec5a454d8d7b192a6f2f5e7eb540f9fbcf914fa0ca0", size = 112291, upload-time = "2026-04-17T00:52:12.422Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/76/41c513917c0e8dc68de0c33578c6a0668b4a09eb4dc3e2782d382dc2947f/azure_keyvault_secrets-4.11.0-py3-none-any.whl", hash = "sha256:d8543b710423569bd00ada2a2533fe83d52d8e1fe026e1c47f41a3bc0fc73ef5", size = 103148, upload-time = "2026-04-17T00:52:13.796Z" },
+]
+
+[[package]]
 name = "azure-storage-blob"
 version = "12.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1272,6 +1286,23 @@ wheels = [
 ]
 
 [[package]]
+name = "google-cloud-secret-manager"
+version = "2.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/7c/5c88cdde9664f6c75fb68aa11e0af4309a92bef38dd38df0456ffb0f469b/google_cloud_secret_manager-2.29.0.tar.gz", hash = "sha256:ee64133af8fdb3780affb65ec6ccf10ab15a0113d8edeba388665f4be87ce1be", size = 278437, upload-time = "2026-06-03T16:13:43.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/c2/fc3275bc42a522757cb5141d7dae51f048b93d2f5fe4574fcee5392cef03/google_cloud_secret_manager-2.29.0-py3-none-any.whl", hash = "sha256:21bac2d0adb0bb3c13c346d7223832f197c2266534528a1bf1402774e06395a3", size = 225042, upload-time = "2026-06-03T16:12:20.162Z" },
+]
+
+[[package]]
 name = "google-cloud-storage"
 version = "3.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1363,7 +1394,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/0f/a91f143f356523ff682309732b175765a9bc2836fd7c081c2c67fedc1ad4/greenlet-3.5.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:8f1cc966c126639cd152fdaa52624d2655f492faa79e013fea161de3e6dda082", size = 284726, upload-time = "2026-04-27T12:20:51.402Z" },
     { url = "https://files.pythonhosted.org/packages/95/82/800646c7ffc5dbabd75ddd2f6b519bb898c0c9c969e5d0473bfe5d20bcce/greenlet-3.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:362624e6a8e5bca3b8233e45eef33903a100e9539a2b995c364d595dbc4018b3", size = 604264, upload-time = "2026-04-27T12:52:39.494Z" },
     { url = "https://files.pythonhosted.org/packages/ca/ac/354867c0bba812fc33b15bc55aedafedd0aee3c7dd91dfca22444157dc0c/greenlet-3.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5ecd83806b0f4c2f53b1018e0005cd82269ea01d42befc0368730028d850ed1c", size = 616099, upload-time = "2026-04-27T12:59:39.623Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ab/192090c4a5b30df148c22bf4b8895457d739a7c7c5a7b9c41e5dd7f537f2/greenlet-3.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa94cb2288681e3a11645958f1871d48ee9211bd2f66628fdace505927d6e564", size = 623976, upload-time = "2026-04-27T13:02:37.363Z" },
     { url = "https://files.pythonhosted.org/packages/ff/b0/815bece7399e01cadb69014219eebd0042339875c59a59b0820a46ece356/greenlet-3.5.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ff251e9a0279522e62f6176412869395a64ddf2b5c5f782ff609a8216a4e662", size = 615198, upload-time = "2026-04-27T12:25:25.928Z" },
+    { url = "https://files.pythonhosted.org/packages/24/11/05eb2b9b188c6df7d68a89c99134d644a7af616a40b9808e8e6ced315d5d/greenlet-3.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:64d6ac45f7271f48e45f67c95b54ef73534c52ec041fcda8edf520c6d811f4bc", size = 418379, upload-time = "2026-04-27T13:05:12.755Z" },
     { url = "https://files.pythonhosted.org/packages/10/80/3b2c0a895d6698f6ddb31b07942ebfa982f3e30888bc5546a5b5990de8b2/greenlet-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d874e79afd41a96e11ff4c5d0bc90a80973e476fda1c2c64985667397df432b", size = 1574927, upload-time = "2026-04-27T12:53:25.81Z" },
     { url = "https://files.pythonhosted.org/packages/44/0e/f354af514a4c61454dbc68e44d47544a5a4d6317e30b77ddfa3a09f4c5f3/greenlet-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0ed006e4b86c59de7467eb2601cd1b77b5a7d657d1ee55e30fe30d76451edba4", size = 1642683, upload-time = "2026-04-27T12:25:23.9Z" },
     { url = "https://files.pythonhosted.org/packages/fa/6a/87f38255201e993a1915265ebb80cd7c2c78b04a45744995abbf6b259fd8/greenlet-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:703cb211b820dbffbbc55a16bfc6e4583a6e6e990f33a119d2cc8b83211119c8", size = 238115, upload-time = "2026-04-27T12:21:48.845Z" },
@@ -1371,7 +1404,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
     { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
     { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
     { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
     { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
     { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
@@ -2160,6 +2195,13 @@ aim = [
     { name = "fsspec" },
     { name = "gcsfs" },
 ]
+aws-secrets = [
+    { name = "boto3" },
+]
+azure-secrets = [
+    { name = "azure-identity" },
+    { name = "azure-keyvault-secrets" },
+]
 data = [
     { name = "docarray" },
     { name = "fsspec" },
@@ -2178,6 +2220,9 @@ flyte = [
     { name = "jsonpickle" },
     { name = "marshmallow-enum" },
     { name = "pyprojroot" },
+]
+gcp-secrets = [
+    { name = "google-cloud-secret-manager" },
 ]
 monitoring = [
     { name = "nvidia-ml-py" },
@@ -2226,6 +2271,9 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "aim", marker = "extra == 'aim'", specifier = ">=3.29.1" },
+    { name = "azure-identity", marker = "extra == 'azure-secrets'" },
+    { name = "azure-keyvault-secrets", marker = "extra == 'azure-secrets'" },
+    { name = "boto3", marker = "extra == 'aws-secrets'" },
     { name = "cookiecutter", marker = "extra == 'flyte'", specifier = ">=2.1.1" },
     { name = "docarray", marker = "extra == 'data'" },
     { name = "docker", marker = "extra == 'flyte'", specifier = ">=7.1.0" },
@@ -2238,6 +2286,7 @@ requires-dist = [
     { name = "gcsfs", marker = "extra == 'aim'", specifier = ">=2024.12.0" },
     { name = "gcsfs", marker = "extra == 'data'", specifier = ">=2024.12.0" },
     { name = "gitpython", marker = "extra == 'flyte'", specifier = ">=3.1.50" },
+    { name = "google-cloud-secret-manager", marker = "extra == 'gcp-secrets'" },
     { name = "hydra-zen" },
     { name = "jsonpickle", marker = "extra == 'flyte'" },
     { name = "lightning", marker = "extra == 'torch'" },
@@ -2253,7 +2302,7 @@ requires-dist = [
     { name = "tqdm", marker = "extra == 'data'" },
     { name = "wandb", marker = "extra == 'wandb'" },
 ]
-provides-extras = ["data", "flyte", "torch", "monitoring", "wandb", "aim"]
+provides-extras = ["data", "flyte", "torch", "monitoring", "wandb", "aim", "aws-secrets", "gcp-secrets", "azure-secrets"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
# Description

## Overview
This PR introduces three independent Hydra plugins that enable secure, lazy-loaded secret injection from AWS Secrets Manager, GCP Secret Manager, and Azure Key Vault directly into Hydra configurations.

## Problem Statement
Previously, managing secrets in Hydra configurations was cumbersome:
- Secrets had to be hardcoded or loaded via environment variables
- No native integration with cloud secret managers
- All cloud SDKs had to be installed even if only one was needed
- No lazy evaluation of secrets

## Solution
Three new modular plugins that:
- ✅ Register custom OmegaConf resolvers for each cloud provider
- ✅ Support lazy evaluation (secrets fetched only when accessed)
- ✅ Keep secrets out of config files and logs
- ✅ Allow independent installation via optional dependencies
- ✅ Follow Hydra's plugin discovery pattern

## Changes

### New Plugins

#### 1. AWS Secrets Manager Plugin
- **Location**: `src/hydra_plugins/aws_secrets_plugin/`
- **Resolver**: `${aws_secret:secret_name, key_name}`
- **Dependencies**: `boto3`
- **Installation**: `pip install mxm-scaffold[aws_secrets]`

**Example**:
```yaml
database:
  host: "prod-db.example.com"
  username: "admin"
  password: "${aws_secret:prod/db/credentials, password}"
```

#### 2. GCP Secret Manager Plugin
- **Location**: `src/hydra_plugins/gcp_secrets_plugin/`
- **Resolver**: `${gcp_secret:project_id/secret_name, key_name}`
- **Dependencies**: `google-cloud-secret-manager`
- **Installation**: `pip install mxm-scaffold[gcp_secrets]`

**Example**:
```yaml
api:
  endpoint: "https://api.example.com"
  key: "${gcp_secret:my-project/api-credentials, api_key}"
```

#### 3. Azure Key Vault Plugin
- **Location**: `src/hydra_plugins/azure_secrets_plugin/`
- **Resolver**: `${azure_secret:vault_name, secret_name}`
- **Dependencies**: `azure-identity`, `azure-keyvault-secrets`
- **Installation**: `pip install mxm-scaffold[azure_secrets]`

**Example**:
```yaml
auth:
  region: "us-east-1"
  token: "${azure_secret:my-vault, auth-token}"
```

### Configuration Changes

**pyproject.toml**:
- Added three new optional dependency groups:
  - `aws_secrets`: boto3
  - `gcp_secrets`: google-cloud-secret-manager
  - `azure_secrets`: azure-identity, azure-keyvault-secrets
- Registered plugin entry points in `[project.entry-points."hydra_plugins"]`

### Testing

**Location**: `test/hydra_plugins/test_resolvers.py`

Tests verify:
- Resolver registration with OmegaConf
- Config creation with resolver syntax
- All three providers

**Run tests**:
```bash
.venv/bin/python -m pytest test/hydra_plugins/ -v
```

## Key Features

### Lazy Evaluation
Secrets are fetched only when accessed, not at config load time:
```python
# Secret is NOT fetched yet
cfg = OmegaConf.create({"password": "${aws_secret:prod/db}"})

# Secret IS fetched here
password = cfg.password
```

### No Hardcoded Values
Config files show only the resolver string:
```yaml
# Safe to commit to version control
password: "${aws_secret:prod/db/credentials, password}"
```

### JSON Key Extraction
Extract specific keys from JSON secrets:
```yaml
# Secret: {"username": "admin", "password": "secret123"}
username: "${aws_secret:db-creds, username}"
password: "${aws_secret:db-creds, password}"
```

### Independent Installation
Users only install what they need:
```bash
# AWS only
pip install mxm-scaffold[aws_secrets]

# Multiple providers
pip install mxm-scaffold[aws_secrets,gcp_secrets]

# All three
pip install mxm-scaffold[aws_secrets,gcp_secrets,azure_secrets]
```

## Usage Example

```python
import hydra
from omegaconf import DictConfig

@hydra.main(version_base=None, config_path="conf", config_name="config")
def my_app(cfg: DictConfig) -> None:
    # Secret is fetched lazily when accessed
    db_password = cfg.database.password
    print(f"Connected with password: {db_password}")

if __name__ == "__main__":
    my_app()
```

**Config file** (`conf/config.yaml`):
```yaml
database:
  host: "prod-db.example.com"
  username: "admin"
  password: "${aws_secret:prod/db/credentials, password}"
```

## Authentication

### AWS
Uses standard boto3 credential chain (IAM role, environment variables, ~/.aws/credentials, etc.)

### GCP
Uses Application Default Credentials (service account key via `GOOGLE_APPLICATION_CREDENTIALS` env var or compute instance identity)

### Azure
Uses `DefaultAzureCredential` (environment variables, managed identity, Azure CLI, etc.)

## Files Changed

**New directories**:
- `src/hydra_plugins/aws_secrets_plugin/` (3 files)
- `src/hydra_plugins/gcp_secrets_plugin/` (3 files)
- `src/hydra_plugins/azure_secrets_plugin/` (3 files)
- `test/hydra_plugins/` (1 test file)

**Modified files**:
- `pyproject.toml`: Added optional dependencies and entry points

## Breaking Changes
None. These are additive features.

## Migration Guide
No migration needed. Existing code continues to work unchanged.

## Testing Recommendations

### Unit Tests
```bash
pytest test/hydra_plugins/ -v
```

### Integration Tests (with real secrets)
Set up a secret in each cloud provider and test end-to-end:

**AWS**:
```bash
aws secretsmanager create-secret --name test/my-secret --secret-string '{"key": "value"}'
```

**GCP**:
```bash
echo "my-secret-value" | gcloud secrets create test-secret --data-file=-
```

**Azure**:
```bash
az keyvault secret set --vault-name my-vault --name test-secret --value my-secret-value
```
Fixes # issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have kept the PR small so that it can be easily reviewed  
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 