### PR TITLE
Backward Compatibility: revert scaffold store entries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mxm-scaffold"
-version = "0.21.0"
+version = "0.21.1"
 description = "Merantix Momentum AI Platform client library"
 authors = [
     {name = "Merantix Momentum GmbH"}

--- a/src/scaffold/conf/__init__.py
+++ b/src/scaffold/conf/__init__.py
@@ -19,9 +19,10 @@ def add_if_not_exists(store: ZenStore, cfg_object: Any, group: str, name: str):
     cs = ConfigStore.instance()
     try:
         cs.list(group)
+        print(cs.list(group))
         if f"{name}.yaml" not in cs.list(group):
             store(cfg_object, group=group, name=name)
-    except (KeyError, IOError):
+    except KeyError:
         # group doesn't exist yet, safe to add
         store(cfg_object, group=group, name=name)
 

--- a/src/scaffold/conf/scaffold/artifact_manager.py
+++ b/src/scaffold/conf/scaffold/artifact_manager.py
@@ -1,6 +1,7 @@
 from hydra_zen import builds
 from omegaconf import MISSING
 
+from scaffold.conf import scaffold_store
 from scaffold.data.artifact_manager.filesystem import FileSystemArtifactManager
 from scaffold.data.artifact_manager.wandb import WandbArtifactManager
 
@@ -19,3 +20,6 @@ FileSystemArtifactManagerConf = builds(
     url=MISSING,
     fs_kwargs={},
 )
+
+scaffold_store(WandbArtifactManagerConf, group=GROUP, name="WandbArtifactManagerConf")
+scaffold_store(FileSystemArtifactManagerConf, group=GROUP, name="FileSystemArtifactManagerConf")

--- a/src/scaffold/conf/scaffold/ctx_manager.py
+++ b/src/scaffold/conf/scaffold/ctx_manager.py
@@ -1,6 +1,7 @@
 from hydra_zen import builds
 from omegaconf import MISSING
 
+from scaffold.conf import scaffold_store
 from scaffold.ctx_manager import WandBContext
 
 WandBContextConf = builds(
@@ -17,3 +18,5 @@ WandBContextConf = builds(
     user=None,
     resume=False,
 )
+
+scaffold_store(WandBContextConf, group="ctx_manager", name="WandBContextConf")

--- a/src/scaffold/conf/scaffold/entrypoint/__init__.py
+++ b/src/scaffold/conf/scaffold/entrypoint/__init__.py
@@ -1,5 +1,6 @@
 from hydra_zen import make_config
 
+from scaffold.conf import scaffold_store
 from scaffold.ctx_manager import (  # noqa: F401
     DEFAULT_LOGGING,
     DISABLED_LOGGING,
@@ -18,3 +19,4 @@ EntrypointConf = make_config(
     logging=DEFAULT_LOGGING,  # Same options as hydra.job_logging; override per logging variant
     verbose=False,  # Same as hydra.verbose, but applied to our logging setup
 )
+scaffold_store(EntrypointConf, group=GROUP, name="EntrypointConf")

--- a/src/scaffold/conf/scaffold/flyte_launcher.py
+++ b/src/scaffold/conf/scaffold/flyte_launcher.py
@@ -2,10 +2,13 @@ from hydra_zen import builds
 from omegaconf import MISSING
 
 from hydra_plugins.flyte_launcher_plugin._flyte_launcher import FlyteLauncher
-from scaffold.flyte.launcher_conf import FlyteDockerImageConf  # noqa: F401
-from scaffold.flyte.launcher_conf import FlyteNotificationConf  # noqa: F401
-from scaffold.flyte.launcher_conf import FlyteWorkflowConf  # noqa: F401
-from scaffold.flyte.launcher_conf import ExecutionEnvironmentEnum
+from scaffold.conf import scaffold_store
+from scaffold.flyte.launcher_conf import (
+    ExecutionEnvironmentEnum,
+    FlyteDockerImageConf,
+    FlyteNotificationConf,
+    FlyteWorkflowConf,
+)
 
 FlyteLauncherConf = builds(
     FlyteLauncher,
@@ -17,3 +20,7 @@ FlyteLauncherConf = builds(
     workflow=MISSING,
     notifications=[],
 )
+
+scaffold_store(FlyteDockerImageConf, group="scaffold/flyte_launcher", name="FlyteDockerImageConf")
+scaffold_store(FlyteWorkflowConf, group="scaffold/flyte_launcher", name="FlyteWorkflowConf")
+scaffold_store(FlyteNotificationConf, group="scaffold/flyte_launcher", name="FlyteNotificationConf")

--- a/src/scaffold/conf/scaffold/lightning/callbacks.py
+++ b/src/scaffold/conf/scaffold/lightning/callbacks.py
@@ -1,6 +1,7 @@
 from hydra_zen import builds
 from omegaconf import MISSING
 
+from scaffold.conf import scaffold_store
 from scaffold.torch.lightning.callbacks import LightningCheckpointer
 
 GROUP = "scaffold/lightning/checkpointer"
@@ -14,3 +15,5 @@ LightningCheckpointerConf = builds(
     resume_checkpoint_version=None,
     only_log_current_best=False,
 )
+
+scaffold_store(LightningCheckpointerConf, group=GROUP, name="LightningCheckpointerConf")

--- a/src/scaffold/hydra/config_helpers.py
+++ b/src/scaffold/hydra/config_helpers.py
@@ -133,8 +133,10 @@ def structured_config(
         Use :func:`hydra_zen.builds` and :func:`hydra_zen.store` instead::
 
             from hydra_zen import builds
+            from scaffold.conf import scaffold_store
 
             MyConf = builds(MyClass, arg=value)
+            scaffold_store(MyConf, group="my/group", name="MyConf")
 
         This decorator will be removed in a future release.
 

--- a/test/scaffold/plugins/test_hydra_plugins.py
+++ b/test/scaffold/plugins/test_hydra_plugins.py
@@ -20,11 +20,20 @@ def test_discovery() -> None:
     assert flyte_launcher.FlyteLauncher.__name__ in [x.__name__ for x in Plugins.instance().discover(Launcher)]
 
 
+def test_config_installed() -> None:
+    """Tests if the scaffold configs are correctly added to the config store."""
+    with initialize(config_path=None):
+        config_loader = GlobalHydra.instance().config_loader()
+        assert "WandbArtifactManagerConf" in config_loader.get_group_options("scaffold/artifact_manager")
+        assert "FlyteWorkflowConf" in config_loader.get_group_options("scaffold/flyte_launcher")
+
+
 def test_flyte_config_installed() -> None:
     """Tests if the flyte related configs are correctly added to the config store."""
     with initialize(config_path=None):
         config_loader = GlobalHydra.instance().config_loader()
-        assert "FlyteWorkflowConfig" in config_loader.get_group_options("scaffold/flyte_launcher")
+        assert "FlyteDockerImageConf" in config_loader.get_group_options("scaffold/flyte_launcher")
+        assert "FlyteWorkflowConf" in config_loader.get_group_options("scaffold/flyte_launcher")
 
 
 def test_hydra_plugin_available() -> None:
@@ -38,7 +47,8 @@ def test_hydra_plugin_available() -> None:
 @pytest.mark.parametrize(
     "config_name",
     [
-        "scaffold/flyte_launcher/FlyteWorkflowConfig",
+        "scaffold/flyte_launcher/FlyteDockerImageConf",
+        "scaffold/flyte_launcher/FlyteWorkflowConf",
     ],
 )
 def test_config_store_available_through_plugin(config_name: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2154,7 +2154,7 @@ wheels = [
 
 [[package]]
 name = "mxm-scaffold"
-version = "0.21.0"
+version = "0.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "hydra-zen" },


### PR DESCRIPTION
# Description

After a short discussion with @yolibernal, we realised there is no nice way of easily referencing the "newer" configs from within a yaml without having to migrate away from yamls. So, for backwards compatibility reasons, we decided to add the old configs to the store again.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [x] Lint and unit tests pass locally with my changes
- [x] I have kept the PR small so that it can be easily reviewed  
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All dependency changes have been reflected in the pip requirement files. 