### PR TITLE
Log remote destination on filesystem artifact upload

### DIFF
--- a/src/scaffold/data/artifact_manager/filesystem.py
+++ b/src/scaffold/data/artifact_manager/filesystem.py
@@ -1,8 +1,11 @@
+import logging
 import typing as t
 
 from scaffold.constants import ARTIFACT_DESCRIPTION_FILE, ARTIFACT_META_DIR
 from scaffold.data.artifact_manager.base import Artifact, ArtifactManager, TmpArtifact
 from scaffold.data.fs import get_fs_from_url, join_path
+
+logger = logging.getLogger(__name__)
 
 
 class FileSystemArtifactManager(ArtifactManager):
@@ -107,11 +110,15 @@ class FileSystemArtifactManager(ArtifactManager):
             parent_dir = fs._parent(target_file)
             self.fs.mkdirs(parent_dir, exist_ok=True)
             self.fs.put(local_path, target_file, recursive=False)
+            logged_location = target_file
         else:
             # Upload an entire folder.
             if not self.fs.exists(target_dir):
                 self.fs.mkdirs(target_dir, exist_ok=True)
             self.fs.put(local_path, target_dir, recursive=True)
+            logged_location = target_dir
+
+        logger.info(f"Logged artifact '{artifact_name}' to {logged_location}")
 
         return Artifact(name=artifact_name, collection=collection, version=new_version)
 


### PR DESCRIPTION
`FileSystemArtifactManager.log_files` now logs the exact remote path it uploaded to (e.g. `gs://.../oof_predictions/v0`), so callers can see where artifacts land without re-deriving the path. It's useful to have this in the logs to see it right away where stuff ended up.