### PR TITLE
docs: update contribution guide for uv

### DIFF
--- a/docs/usage/contribute.rst
+++ b/docs/usage/contribute.rst
@@ -3,29 +3,29 @@ Contribute
 
 To contribute to developing this package, check out its GitHub repository and push commits there.
 
-
 Dependency Management
 ---------------------
 
-We use poetry for resolving and installing dependencies.
-For an overview of poetry basic commands, visit the `official documentation: <https://python-poetry.org/docs>`_
+We use `uv <https://docs.astral.sh/uv/>`_ for resolving and installing dependencies.
+For an overview of the basic uv commands, visit the `official documentation <https://docs.astral.sh/uv/getting-started/features/>`_.
 
-#. `Install poetry <https://python-poetry.org/docs/#installation>`_
-#. Install the dependencies: ``poetry install --all-extras``. Poetry creates a virtual environment for you.
-#. You can activate the venv using ``poetry shell`` or temporarily ``poetry run [command]``.
-#. When adding new dependencies, use ``poetry add [my-package]`` or
-   add them manually to ``pyproject.toml`` and update the lockfile ``poetry lock --no-update``.
-#. Commit ``poetry.lock`` in a PR.
-   Once merged to main, GitHub Actions will build the image with the new dependencies.
+#. `Install uv <https://docs.astral.sh/uv/getting-started/installation/>`_.
+#. Install the dependencies with ``uv sync --all-extras --group docs``.
+   uv creates a virtual environment in ``.venv``.
+#. You can run commands in the virtual environment with ``uv run [command]``.
+#. When adding new dependencies, use ``uv add [my-package]``.
+   Use ``uv add --dev [my-package]`` for a development dependency or
+   ``uv add --group docs [my-package]`` for a documentation dependency.
+#. Commit ``pyproject.toml`` and ``uv.lock`` in a PR when dependencies change.
+   Once merged into main, GitHub Actions will build the image with the new dependencies.
 
 Tests
 -----
 
-You can run tests by executing ``poetry run pytest -n auto``.
+You can run tests by executing ``uv run pytest -n auto``.
 
 Build the documentation locally
 -------------------------------
 
-Running ``poetry run sphinx-build ./docs ./docs/build`` from the root directory will generate the documentation.
-Currently, this only works on python3.9.
-You can use poetry with python3.10 by running ``poetry env use 3.10`` before ``poetry install --all-extras``.
+Running ``uv run sphinx-build -b html ./docs ./docs/_build/html`` from the repository root will generate the documentation.
+Scaffold supports Python 3.11 and 3.12.


### PR DESCRIPTION
# Description

This PR updates the contribution guide to match the project's current uv-based development workflow.

* Replaces outdated Poetry commands with uv commands
* Updates the supported Python versions to 3.11 and 3.12
* Replaces `poetry.lock` guidance with `pyproject.toml` and `uv.lock`
* Updates the test and Sphinx documentation build commands

No runtime code or dependencies were changed. This contribution was discussed with @adrianloy.

## Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] Documentation update
* [ ] Refactoring
* [ ] Other

## Validation

* [x] `uv lock --check`
* [x] `uv sync --frozen --group docs --no-default-groups`
* [x] `uv run --frozen --group docs --no-default-groups sphinx-build -b html ./docs ./docs/_build/html`
* [x] `git diff --check`

The documentation build completed successfully. It still reports existing AutoAPI and theme warnings that are unrelated to this change.

## Checklist

* [ ] Lint and unit tests pass locally with my changes
* [x] I have kept the PR small so that it can be easily reviewed
* [x] I have made the corresponding documentation changes
* [ ] I have added tests that prove my fix is effective
* [ ] All dependency changes have been reflected in the requirement files

The unchecked test and dependency items are not applicable because this is a documentation-only change with no runtime or dependency modifications.
